### PR TITLE
Ensure server tasks match assigned controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# SpaceShip Multiplayer Konsolen-Spiel
+
+## Überblick
+Dieses Projekt besteht aus einem WebSocket-Server (`space_server.py`) und einem webbasierten Client (`space_client.html`). Gemeinsam bilden sie ein kooperatives Multiplayer-Minispiel, bei dem mehrere Spieler*innen unterschiedliche Kontrollflächen bedienen, um Notfälle auf einem Raumschiff zu lösen.
+
+Der Python-Server verteilt zufällig generierte Steuerelemente an die verbundenen Clients, startet Aufgaben und bewertet die Eingaben. Die HTML/JavaScript-Oberfläche stellt für jedes Endgerät eine individuelle Konsole dar.
+
+## Voraussetzungen
+- Python 3.9 oder neuer
+- Abhängigkeiten:
+  - `websockets` (per `pip install websockets`)
+  - `tkinter` (bei vielen Python-Distributionen bereits enthalten)
+- Ein moderner Browser auf den Endgeräten der Spieler*innen
+- Alle Geräte müssen sich im selben Netzwerk befinden
+
+## Installation
+1. Repository klonen oder entpacken.
+2. Abhängigkeiten installieren:
+   ```bash
+   pip install websockets
+   ```
+
+## Server starten
+1. Stelle sicher, dass sich alle Dateien im selben Verzeichnis befinden.
+2. Starte den Server auf dem Host-Rechner (z. B. Laptop/PC, der im selben Netz wie die mobilen Geräte ist):
+   ```bash
+   python space_server.py
+   ```
+3. Es öffnet sich eine Desktop-GUI, die den aktuellen Spielstatus, verbundene Geräte sowie die IP-Adresse des Servers anzeigt.
+4. Über die Buttons in der GUI kann das Spiel gestartet oder gestoppt werden.
+
+## Client verbinden
+1. Öffne die Datei `space_client.html` auf dem Endgerät der Spieler*innen in einem Browser. (Lokales Öffnen genügt; ein Webserver ist nicht erforderlich.)
+2. Gib im Startbildschirm die IP-Adresse ein, die in der Server-GUI angezeigt wird. Der Port ist fest auf `8765` gesetzt.
+3. Nach erfolgreicher Verbindung blendet der Client den Steuerungsbereich ein. Jede Session erhält eigene Steuerelemente mit unterschiedlichen Farben, Formen und Interaktionen.
+
+## Spielablauf
+- Der Server wählt zufällig Aufgaben aus, die gelöst werden müssen (z. B. "Schilde verstärken").
+- Im Client erscheint das aktuelle Problem sowie die Anweisung, welche Kontrolle (z. B. roter Slider auf Position 2) betätigt werden soll.
+- Wenn die richtige Kontrolle in den vorgegebenen Zustand versetzt wird, vergibt der Server Punkte und generiert eine neue Aufgabe.
+- Erfolgreiche Aktionen werden an alle verbundenen Clients gesendet; die Server-GUI zeigt den Punktestand und das aktive Problem.
+
+## Hinweise zur Erweiterung
+- `space_server.py` ist modular aufgebaut und kann erweitert werden (z. B. für persistente Highscores, zusätzliche Kontrolltypen oder komplexere Aufgabenlogik).
+- `space_client.html` nutzt einfache DOM-Manipulation. Zusätzliche UI-Elemente oder Styling-Anpassungen können direkt in der Datei vorgenommen werden.
+- Aktuell werden Kontrollen zufällig generiert. Für konsistentere Spielerlebnisse könnte man vordefinierte Sets erstellen.
+
+## Troubleshooting
+- **Keine Verbindung möglich:** Prüfe Firewall-Einstellungen und ob alle Geräte im selben Netzwerk sind.
+- **Tkinter-Fehler:** Unter manchen Linux-Distributionen muss das Paket `python3-tk` nachinstalliert werden.
+- **Browser blockiert WebSockets:** Verwende einen aktuellen Browser (Chrome, Firefox, Safari, Edge). Manche mobile Browser benötigen HTTPS für WebSockets; bei lokalen Netzen funktioniert HTTP jedoch in der Regel.
+
+Viel Spaß bei der Weltraum-Mission! 🚀

--- a/space_client.html
+++ b/space_client.html
@@ -66,6 +66,12 @@
             background: rgba(0, 255, 0, 0.2);
             border-color: #00ff00;
         }
+
+        .status.my-turn {
+            box-shadow: 0 0 20px rgba(0, 255, 255, 0.7);
+            border-color: #00ffff;
+            background: rgba(0, 128, 255, 0.2);
+        }
         
         .problem {
             font-size: 16px;
@@ -196,6 +202,13 @@
             font-size: 24px;
             font-weight: bold;
             color: #00ffff;
+        }
+
+        .button-counter {
+            margin-top: 10px;
+            font-size: 20px;
+            font-weight: bold;
+            color: #ffcc00;
         }
         
         .button-control {
@@ -356,6 +369,7 @@
                     document.getElementById('deviceId').textContent = deviceId;
                     document.getElementById('connectScreen').style.display = 'none';
                     document.getElementById('mainContainer').style.display = 'flex';
+                    document.getElementById('status').classList.remove('success', 'my-turn');
                     renderControls();
                     break;
                     
@@ -363,13 +377,16 @@
                     document.getElementById('problem').textContent = data.problem;
                     document.getElementById('instruction').textContent = data.instruction;
                     document.getElementById('status').classList.remove('success');
+                    document.getElementById('status').classList.toggle('my-turn', data.target_device === deviceId);
                     break;
-                    
+
                 case 'success':
                     document.getElementById('problem').textContent = data.message;
                     document.getElementById('instruction').textContent = `Punkte: ${data.score}`;
-                    document.getElementById('status').classList.add('success');
-                    
+                    const statusElement = document.getElementById('status');
+                    statusElement.classList.add('success');
+                    statusElement.classList.remove('my-turn');
+
                     // Vibriere bei Erfolg (falls unterstützt)
                     if (navigator.vibrate) {
                         navigator.vibrate([100, 50, 100]);
@@ -385,25 +402,34 @@
             controls.forEach((control, index) => {
                 const box = document.createElement('div');
                 box.className = `control-box ${control.color}`;
-                
+
                 const label = document.createElement('div');
                 label.className = 'control-label';
-                label.textContent = `${control.color.toUpperCase()}\n${control.type.toUpperCase()}`;
+                label.textContent = `${control.label.toUpperCase()}\n(${control.color.toUpperCase()})`;
                 box.appendChild(label);
-                
+
                 if (control.type === 'schalter') {
                     const container = document.createElement('div');
                     container.className = 'switch-container';
-                    
+
                     const button = document.createElement('div');
                     button.className = 'switch-button';
-                    button.textContent = control.position || '0';
+                    const min = control.min_value ?? 0;
+                    const max = control.max_value ?? 3;
+                    if (typeof control.position !== 'number') {
+                        control.position = min;
+                    }
+                    button.textContent = control.position;
                     button.onclick = () => {
-                        control.position = (control.position % 3) + 1;
+                        let next = control.position + 1;
+                        if (next > max) {
+                            next = min;
+                        }
+                        control.position = next;
                         button.textContent = control.position;
                         sendControlChange(control.id, control.position);
                     };
-                    
+
                     container.appendChild(button);
                     box.appendChild(container);
                 } else if (control.type === 'slider') {
@@ -412,17 +438,21 @@
                     
                     const slider = document.createElement('input');
                     slider.type = 'range';
-                    slider.min = '0';
-                    slider.max = '3';
-                    slider.value = control.position || '0';
+                    const sliderMin = control.min_value ?? 0;
+                    const sliderMax = control.max_value ?? 3;
+                    slider.min = sliderMin;
+                    slider.max = sliderMax;
+                    const sliderValue = (typeof control.position === 'number') ? control.position : sliderMin;
+                    control.position = sliderValue;
+                    slider.value = sliderValue;
                     slider.className = 'slider';
-                    
+
                     const value = document.createElement('div');
                     value.className = 'slider-value';
                     value.textContent = slider.value;
                     
                     slider.oninput = () => {
-                        control.position = parseInt(slider.value);
+                        control.position = parseInt(slider.value, 10);
                         value.textContent = slider.value;
                         sendControlChange(control.id, control.position);
                     };
@@ -435,10 +465,24 @@
                     button.className = 'button-control';
                     button.textContent = 'DRÜCK\nMICH!';
                     button.style.whiteSpace = 'pre';
+                    const min = control.min_value ?? 0;
+                    const max = control.max_value ?? 3;
+                    if (typeof control.position !== 'number') {
+                        control.position = min;
+                    }
+
+                    const counter = document.createElement('div');
+                    counter.className = 'button-counter';
+                    counter.textContent = control.position;
                     button.onclick = () => {
-                        control.position = (control.position || 0) + 1;
+                        let next = control.position + 1;
+                        if (next > max) {
+                            next = min;
+                        }
+                        control.position = next;
+                        counter.textContent = control.position;
                         sendControlChange(control.id, control.position);
-                        
+
                         // Visuelles Feedback
                         button.style.background = 'rgba(255, 255, 255, 0.5)';
                         setTimeout(() => {
@@ -446,8 +490,9 @@
                         }, 200);
                     };
                     box.appendChild(button);
+                    box.appendChild(counter);
                 }
-                
+
                 grid.appendChild(box);
             });
         }

--- a/space_server.py
+++ b/space_server.py
@@ -6,12 +6,43 @@ import tkinter as tk
 from threading import Thread
 
 class SpaceGameServer:
+    CONTROL_LIBRARY = [
+        {"name": "Antrieb", "type": "schalter", "color": "rot", "min_value": 0, "max_value": 3},
+        {"name": "Schilde", "type": "slider", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Navigation", "type": "knopf", "color": "grün", "min_value": 0, "max_value": 3},
+        {"name": "Kommunikation", "type": "schalter", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Triebwerk", "type": "slider", "color": "rot", "min_value": 0, "max_value": 4},
+        {"name": "Scanner", "type": "knopf", "color": "blau", "min_value": 0, "max_value": 4},
+        {"name": "Laser", "type": "knopf", "color": "rot", "min_value": 0, "max_value": 3},
+        {"name": "Fracht", "type": "slider", "color": "grün", "min_value": 0, "max_value": 5},
+        {"name": "Sauerstoff", "type": "schalter", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Gravitation", "type": "slider", "color": "gelb", "min_value": 0, "max_value": 3},
+        {"name": "Lebenserhaltung", "type": "schalter", "color": "grün", "min_value": 0, "max_value": 2},
+        {"name": "Turbinen", "type": "slider", "color": "rot", "min_value": 0, "max_value": 4},
+        {"name": "Dock", "type": "knopf", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Sensor Boost", "type": "slider", "color": "blau", "min_value": 0, "max_value": 5},
+        {"name": "Plasma", "type": "schalter", "color": "rot", "min_value": 0, "max_value": 3},
+        {"name": "Schildgenerator", "type": "knopf", "color": "grün", "min_value": 0, "max_value": 4},
+        {"name": "Funk", "type": "slider", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Verteidigung", "type": "schalter", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Warp", "type": "slider", "color": "grün", "min_value": 0, "max_value": 4},
+        {"name": "Kühlung", "type": "schalter", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Analyse", "type": "knopf", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Versorgung", "type": "slider", "color": "grün", "min_value": 0, "max_value": 5},
+        {"name": "Stabilisator", "type": "schalter", "color": "rot", "min_value": 0, "max_value": 2},
+        {"name": "Hangar", "type": "knopf", "color": "gelb", "min_value": 0, "max_value": 3},
+    ]
+
     def __init__(self):
         self.clients = {}
+        self.client_controls = {}
+        self.client_control_specs = {}
         self.current_task = None
         self.score = 0
         self.game_active = False
         self.loop = None
+        self.available_controls = self.CONTROL_LIBRARY.copy()
+        self.extra_control_counter = 1
         self.problems = [
             "WARNUNG: Sauerstoff niedrig!",
             "ALARM: Energiekern überhitzt!",
@@ -19,55 +50,100 @@ class SpaceGameServer:
             "GEFAHR: Antrieb ausgefallen!",
             "WARNUNG: Sensoren offline!"
         ]
-        
+
     async def register_client(self, websocket):
         client_id = f"device_{len(self.clients) + 1}"
         self.clients[client_id] = websocket
         print(f"Neues Gerät verbunden: {client_id}")
-        
+
+        controls = self.generate_controls(client_id)
+        self.client_controls[client_id] = controls
+
         # Sende Geräte-ID und initiale Konfiguration
         await websocket.send(json.dumps({
             "type": "init",
             "device_id": client_id,
-            "controls": self.generate_controls()
+            "controls": controls
         }))
-        
+
+        self.update_gui()
+
         try:
             async for message in websocket:
                 data = json.loads(message)
                 await self.handle_message(data, client_id)
         except websockets.exceptions.ConnectionClosed:
             print(f"Gerät getrennt: {client_id}")
+        finally:
             if client_id in self.clients:
                 del self.clients[client_id]
+
+            if client_id in self.client_controls:
+                del self.client_controls[client_id]
+
+            if client_id in self.client_control_specs:
+                self.available_controls.extend(self.client_control_specs[client_id])
+                del self.client_control_specs[client_id]
+
+            if self.current_task and self.current_task.get("device_id") == client_id:
+                self.current_task = None
+
             self.update_gui()
-    
-    def generate_controls(self):
-        colors = ["rot", "grün", "blau", "gelb"]
-        shapes = ["rund", "eckig"]
-        control_types = ["schalter", "slider", "knopf"]
-        
+
+    def generate_controls(self, client_id):
+        if len(self.available_controls) < 6:
+            assigned_specs = []
+            for specs in self.client_control_specs.values():
+                assigned_specs.extend(specs)
+
+            self.available_controls = [
+                spec for spec in self.CONTROL_LIBRARY
+                if spec not in assigned_specs
+            ]
+
+            if len(self.available_controls) < 6:
+                # Falls nicht genug einzigartige Kontrollen verfügbar sind,
+                # generieren wir zusätzliche Varianten mit nummerierten Namen.
+                extra_controls = []
+                while len(self.available_controls) + len(extra_controls) < 6:
+                    template = random.choice(self.CONTROL_LIBRARY)
+                    extra = template.copy()
+                    extra["name"] = f"{template['name']} {self.extra_control_counter}"
+                    extra_controls.append(extra)
+                    self.extra_control_counter += 1
+
+                self.available_controls.extend(extra_controls)
+
+        selected_specs = random.sample(self.available_controls, k=6)
+        for spec in selected_specs:
+            self.available_controls.remove(spec)
+
+        self.client_control_specs[client_id] = selected_specs
+
         controls = []
-        for i in range(6):
-            control = {
-                "id": f"control_{i}",
-                "type": random.choice(control_types),
-                "color": random.choice(colors),
-                "shape": random.choice(shapes) if random.random() > 0.5 else None,
-                "position": 0
-            }
-            controls.append(control)
+        for index, spec in enumerate(selected_specs):
+            controls.append({
+                "id": f"{client_id}_control_{index}",
+                "type": spec["type"],
+                "color": spec["color"],
+                "label": spec["name"],
+                "min_value": spec.get("min_value", 0),
+                "max_value": spec.get("max_value", 3),
+                "position": spec.get("min_value", 0)
+            })
+
         return controls
-    
+
     async def handle_message(self, data, client_id):
         if data["type"] == "control_change":
             await self.check_solution(data, client_id)
-    
+
     async def check_solution(self, data, client_id):
         if not self.current_task:
             return
-        
-        if (data["control_id"] == self.current_task["target_control"] and
+
+        if (client_id == self.current_task.get("device_id") and
+            data["control_id"] == self.current_task["target_control"] and
             data["value"] == self.current_task["target_value"]):
             self.score += 10
             await self.broadcast({
@@ -75,47 +151,82 @@ class SpaceGameServer:
                 "message": "SUPER! Problem gelöst! ⭐",
                 "score": self.score
             })
+            self.current_task = None
             self.update_gui()
             await asyncio.sleep(2)
             await self.send_new_task()
-    
+
     async def send_new_task(self):
         if not self.clients or not self.game_active:
             return
-        
-        # Wähle zufälliges Gerät und Kontrolle
-        device_id = random.choice(list(self.clients.keys()))
-        control_id = f"control_{random.randint(0, 5)}"
-        target_value = random.randint(1, 3)
-        
-        # Hole Kontrollinformationen (simuliert)
-        colors = ["rot", "grün", "blau", "gelb"]
-        types = ["Schalter", "Slider", "Knopf"]
-        
-        instruction = f"{random.choice(colors).capitalize()} {random.choice(types)} auf Position {target_value}!"
-        
+
+        device_id = random.choice(list(self.client_controls.keys()))
+        available_controls = self.client_controls.get(device_id, [])
+
+        if not available_controls:
+            return
+
+        control = random.choice(available_controls)
+        target_value = self.generate_target_value(control)
+        instruction = self.build_instruction(device_id, control, target_value)
+
         self.current_task = {
-            "target_control": control_id,
+            "device_id": device_id,
+            "target_control": control["id"],
             "target_value": target_value,
             "problem": random.choice(self.problems),
             "instruction": instruction
         }
-        
+
         await self.broadcast({
             "type": "new_task",
             "problem": self.current_task["problem"],
-            "instruction": instruction
+            "instruction": instruction,
+            "target_device": device_id
         })
-        
+
         self.update_gui()
-    
+
+    def generate_target_value(self, control):
+        min_value = control.get("min_value", 0)
+        max_value = control.get("max_value", 3)
+
+        if control["type"] == "slider":
+            return random.randint(min_value, max_value)
+
+        if control["type"] == "schalter":
+            return random.randint(min_value, max_value)
+
+        # knopf
+        target = random.randint(min_value + 1, max_value)
+        return target
+
+    def build_instruction(self, device_id, control, target_value):
+        type_labels = {
+            "schalter": "Schalter",
+            "slider": "Regler",
+            "knopf": "Knopf"
+        }
+
+        color = control.get("color", "").capitalize()
+        label = control.get("label", "Kontrolle")
+        type_label = type_labels.get(control.get("type"), "Kontrolle")
+
+        if control["type"] == "slider":
+            return (f"{device_id.upper()}: Stelle den {color} {type_label} '{label}' auf Stufe {target_value}.")
+
+        if control["type"] == "schalter":
+            return (f"{device_id.upper()}: Schalte '{label}' ({color}) auf Position {target_value}.")
+
+        return (f"{device_id.upper()}: Drücke '{label}' ({color}) bis Anzeige {target_value} leuchtet.")
+
     async def broadcast(self, message):
         if self.clients:
             await asyncio.gather(
                 *[client.send(json.dumps(message)) for client in self.clients.values()],
                 return_exceptions=True
             )
-    
+
     def update_gui(self):
         if hasattr(self, 'gui') and self.gui:
             try:
@@ -126,8 +237,9 @@ class SpaceGameServer:
     async def start_game(self):
         self.game_active = True
         self.score = 0
+        self.current_task = None
         await self.send_new_task()
-    
+
     async def stop_game(self):
         self.game_active = False
         self.current_task = None


### PR DESCRIPTION
## Summary
- keep track of per-device control layouts and generate tasks based on the actual controls
- expand control metadata so clients receive min/max ranges and clearer instructions, including targeted player info
- update the client UI to reflect the enriched control data, add turn highlighting, and show button counters

## Testing
- python -m compileall space_server.py space_client.html

------
https://chatgpt.com/codex/tasks/task_e_68e4e45d76a4832c9857fc78fabc7dee