### PR TITLE
Highlight targeted controls for incoming tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# SpaceShip Multiplayer Konsolen-Spiel
+
+## Überblick
+Dieses Projekt besteht aus einem WebSocket-Server (`space_server.py`) und einem webbasierten Client (`space_client.html`). Gemeinsam bilden sie ein kooperatives Multiplayer-Minispiel, bei dem mehrere Spieler*innen unterschiedliche Kontrollflächen bedienen, um Notfälle auf einem Raumschiff zu lösen.
+
+Der Python-Server verteilt zufällig generierte Steuerelemente an die verbundenen Clients, startet Aufgaben und bewertet die Eingaben. Die HTML/JavaScript-Oberfläche stellt für jedes Endgerät eine individuelle Konsole dar.
+
+## Voraussetzungen
+- Python 3.9 oder neuer
+- Abhängigkeiten:
+  - `websockets` (per `pip install websockets`)
+  - `tkinter` (bei vielen Python-Distributionen bereits enthalten)
+- Ein moderner Browser auf den Endgeräten der Spieler*innen
+- Alle Geräte müssen sich im selben Netzwerk befinden
+
+## Installation
+1. Repository klonen oder entpacken.
+2. Abhängigkeiten installieren:
+   ```bash
+   pip install websockets
+   ```
+
+## Server starten
+1. Stelle sicher, dass sich alle Dateien im selben Verzeichnis befinden.
+2. Starte den Server auf dem Host-Rechner (z. B. Laptop/PC, der im selben Netz wie die mobilen Geräte ist):
+   ```bash
+   python space_server.py
+   ```
+3. Es öffnet sich eine Desktop-GUI, die den aktuellen Spielstatus, verbundene Geräte sowie die IP-Adresse des Servers anzeigt.
+4. Über die Buttons in der GUI kann das Spiel gestartet oder gestoppt werden.
+
+## Client verbinden
+1. Öffne die Datei `space_client.html` auf dem Endgerät der Spieler*innen in einem Browser. (Lokales Öffnen genügt; ein Webserver ist nicht erforderlich.)
+2. Gib im Startbildschirm die IP-Adresse ein, die in der Server-GUI angezeigt wird. Der Port ist fest auf `8765` gesetzt.
+3. Nach erfolgreicher Verbindung blendet der Client den Steuerungsbereich ein. Jede Session erhält eigene Steuerelemente mit unterschiedlichen Farben, Formen und Interaktionen.
+
+## Spielablauf
+- Der Server wählt zufällig Aufgaben aus, die gelöst werden müssen (z. B. "Schilde verstärken").
+- Im Client erscheint das aktuelle Problem sowie die Anweisung, welche Kontrolle (z. B. roter Slider auf Position 2) betätigt werden soll.
+- Wenn die richtige Kontrolle in den vorgegebenen Zustand versetzt wird, vergibt der Server Punkte und generiert eine neue Aufgabe.
+- Erfolgreiche Aktionen werden an alle verbundenen Clients gesendet; die Server-GUI zeigt den Punktestand und das aktive Problem.
+
+## Hinweise zur Erweiterung
+- `space_server.py` ist modular aufgebaut und kann erweitert werden (z. B. für persistente Highscores, zusätzliche Kontrolltypen oder komplexere Aufgabenlogik).
+- `space_client.html` nutzt einfache DOM-Manipulation. Zusätzliche UI-Elemente oder Styling-Anpassungen können direkt in der Datei vorgenommen werden.
+- Aktuell werden Kontrollen zufällig generiert. Für konsistentere Spielerlebnisse könnte man vordefinierte Sets erstellen.
+
+## Troubleshooting
+- **Keine Verbindung möglich:** Prüfe Firewall-Einstellungen und ob alle Geräte im selben Netzwerk sind.
+- **Tkinter-Fehler:** Unter manchen Linux-Distributionen muss das Paket `python3-tk` nachinstalliert werden.
+- **Browser blockiert WebSockets:** Verwende einen aktuellen Browser (Chrome, Firefox, Safari, Edge). Manche mobile Browser benötigen HTTPS für WebSockets; bei lokalen Netzen funktioniert HTTP jedoch in der Regel.
+
+Viel Spaß bei der Weltraum-Mission! 🚀

--- a/space_client.html
+++ b/space_client.html
@@ -14,132 +14,300 @@
         
         body {
             font-family: 'Arial', sans-serif;
-            background: linear-gradient(135deg, #001a33 0%, #003366 100%);
+            background: linear-gradient(135deg, rgba(0, 10, 25, 0.95) 0%, rgba(0, 40, 85, 0.9) 100%),
+                radial-gradient(circle at 20% 20%, rgba(0, 180, 255, 0.18), transparent 55%),
+                radial-gradient(circle at 80% 80%, rgba(0, 255, 175, 0.15), transparent 60%);
+            background-blend-mode: screen, normal;
             color: white;
             overflow: hidden;
             height: 100vh;
             touch-action: none;
+            position: relative;
         }
-        
+
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><rect width='400' height='400' fill='rgba(0,0,0,0)'/><g fill='rgba(255,255,255,0.4)'><circle cx='20' cy='30' r='1.2'/><circle cx='180' cy='80' r='1.5'/><circle cx='360' cy='40' r='1.1'/><circle cx='120' cy='300' r='1.3'/><circle cx='300' cy='200' r='1.4'/><circle cx='60' cy='200' r='1.2'/><circle cx='250' cy='340' r='1.1'/><circle cx='340' cy='280' r='1.0'/><circle cx='80' cy='100' r='1.6'/></g></svg>");
+            background-size: 400px 400px;
+            opacity: 0.6;
+            animation: driftStars 120s linear infinite;
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        body::after {
+            content: '';
+            position: fixed;
+            inset: 0;
+            background: radial-gradient(circle at 50% 0%, rgba(0, 255, 255, 0.08), transparent 55%),
+                        radial-gradient(circle at 50% 100%, rgba(255, 100, 0, 0.06), transparent 60%);
+            pointer-events: none;
+            z-index: 0;
+        }
+
         .container {
             height: 100vh;
             display: flex;
             flex-direction: column;
             padding: 10px;
+            position: relative;
+            z-index: 1;
+        }
+
+        .container::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='900' height='600' viewBox='0 0 900 600'><defs><linearGradient id='panel' x1='0' y1='0' x2='0' y2='1'><stop offset='0%' stop-color='rgba(10,40,70,0.7)'/><stop offset='100%' stop-color='rgba(5,20,40,0.5)'/></linearGradient><radialGradient id='glow' cx='0.5' cy='0.2' r='0.7'><stop offset='0%' stop-color='rgba(0,180,255,0.35)'/><stop offset='100%' stop-color='rgba(0,0,0,0)'/></radialGradient></defs><rect width='900' height='600' rx='32' ry='32' fill='url(%23panel)' stroke='rgba(0,255,255,0.08)' stroke-width='4'/><ellipse cx='450' cy='120' rx='280' ry='80' fill='url(%23glow)'/><g stroke='rgba(0,255,255,0.12)' stroke-width='1' fill='none'><path d='M60 160h780'/><path d='M60 440h780'/><path d='M120 200v320'/><path d='M780 200v320'/></g></svg>");
+            background-size: cover;
+            opacity: 0.35;
+            filter: drop-shadow(0 40px 80px rgba(0, 0, 0, 0.45));
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .container > * {
+            position: relative;
+            z-index: 1;
         }
         
         .header {
             text-align: center;
-            padding: 15px;
-            background: rgba(0, 255, 0, 0.1);
-            border-radius: 10px;
-            margin-bottom: 10px;
-            border: 2px solid #00ff00;
+            padding: 20px;
+            background: linear-gradient(135deg, rgba(0, 60, 120, 0.6), rgba(0, 25, 45, 0.8));
+            border-radius: 18px;
+            margin-bottom: 12px;
+            border: 2px solid rgba(0, 255, 200, 0.35);
+            box-shadow: 0 12px 25px rgba(0, 0, 0, 0.4);
         }
-        
+
         .header h1 {
-            font-size: 24px;
-            color: #00ff00;
-            text-shadow: 0 0 10px #00ff00;
+            font-size: 26px;
+            color: #5cffd7;
+            text-shadow: 0 0 20px rgba(0, 255, 255, 0.8);
+            letter-spacing: 2px;
         }
-        
+
         .device-id {
             font-size: 14px;
-            color: #aaa;
-            margin-top: 5px;
+            color: #7cd0ff;
+            margin-top: 6px;
         }
         
         .status {
-            background: rgba(255, 0, 0, 0.2);
-            border: 2px solid #ff3333;
-            border-radius: 10px;
-            padding: 15px;
-            margin-bottom: 10px;
+            background: linear-gradient(135deg, rgba(30, 0, 0, 0.65), rgba(60, 0, 0, 0.45));
+            border: 2px solid rgba(255, 80, 80, 0.65);
+            border-radius: 16px;
+            padding: 18px;
+            margin-bottom: 14px;
             text-align: center;
-            min-height: 80px;
+            min-height: 90px;
             display: flex;
             flex-direction: column;
             justify-content: center;
+            box-shadow: 0 15px 35px rgba(0, 0, 0, 0.45);
+            transition: box-shadow 0.3s, border-color 0.3s, background 0.3s;
         }
         
         .status.success {
-            background: rgba(0, 255, 0, 0.2);
-            border-color: #00ff00;
+            background: linear-gradient(135deg, rgba(0, 120, 40, 0.65), rgba(0, 200, 120, 0.35));
+            border-color: rgba(0, 255, 120, 0.8);
+            box-shadow: 0 20px 40px rgba(0, 255, 160, 0.25);
+        }
+
+        .status.my-turn {
+            box-shadow: 0 0 25px rgba(0, 255, 255, 0.8);
+            border-color: rgba(0, 255, 255, 0.8);
+            background: linear-gradient(135deg, rgba(0, 40, 120, 0.65), rgba(0, 160, 255, 0.35));
         }
         
         .problem {
-            font-size: 16px;
+            font-size: 18px;
             font-weight: bold;
-            color: #ffcc00;
+            color: #ffd15c;
             margin-bottom: 8px;
+            text-shadow: 0 0 8px rgba(255, 209, 92, 0.5);
         }
-        
+
         .instruction {
             font-size: 18px;
-            color: #00ffff;
+            color: #6ff9ff;
             font-weight: bold;
+            text-shadow: 0 0 8px rgba(111, 249, 255, 0.6);
         }
-        
+
         .controls-grid {
             flex: 1;
             display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 15px;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 18px;
             overflow-y: auto;
-            padding: 10px;
+            padding: 12px;
         }
-        
+
         .control-box {
-            background: rgba(255, 255, 255, 0.1);
-            border-radius: 15px;
-            padding: 20px;
+            background: rgba(8, 30, 60, 0.65);
+            border-radius: 18px;
+            padding: 22px 18px 20px;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            border: 3px solid;
+            border: 3px solid rgba(255, 255, 255, 0.25);
             position: relative;
-            min-height: 150px;
+            min-height: 170px;
+            box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45);
+            overflow: hidden;
+            backdrop-filter: blur(4px);
         }
-        
-        .control-box.rot { 
-            border-color: #ff3333;
-            background: linear-gradient(135deg, rgba(255, 51, 51, 0.3), rgba(255, 51, 51, 0.1));
+
+        .control-box::after {
+            content: '';
+            position: absolute;
+            inset: 6px;
+            border-radius: 14px;
+            background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><path d='M0 40h200M0 120h200M40 0v200M160 0v200' stroke='rgba(255,255,255,0.06)' stroke-width='2'/></svg>");
+            background-size: 140px 140px;
+            opacity: 0.4;
+            pointer-events: none;
+            mix-blend-mode: screen;
         }
-        .control-box.grün { 
-            border-color: #00ff00;
-            background: linear-gradient(135deg, rgba(0, 255, 0, 0.3), rgba(0, 255, 0, 0.1));
+
+        .control-box.type-schalter::before,
+        .control-box.type-toggle::before,
+        .control-box.type-slider::before,
+        .control-box.type-knopf::before,
+        .control-box.type-dial::before {
+            content: '';
+            position: absolute;
+            inset: 12px;
+            border-radius: 12px;
+            opacity: 0.3;
+            filter: blur(0.3px);
         }
-        .control-box.blau { 
-            border-color: #3333ff;
-            background: linear-gradient(135deg, rgba(51, 51, 255, 0.3), rgba(51, 51, 255, 0.1));
+
+        .control-box.type-schalter::before {
+            background: radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.25), transparent 60%),
+                        linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0));
         }
-        .control-box.gelb { 
-            border-color: #ffff00;
-            background: linear-gradient(135deg, rgba(255, 255, 0, 0.3), rgba(255, 255, 0, 0.1));
+
+        .control-box.type-slider::before {
+            background: linear-gradient(90deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 40%),
+                        linear-gradient(270deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 60%);
         }
-        
+
+        .control-box.type-knopf::before {
+            background: radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.25), transparent 55%),
+                        radial-gradient(circle at 50% 70%, rgba(255, 255, 255, 0.1), transparent 65%);
+        }
+
+        .control-box.type-toggle::before {
+            background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0, rgba(255, 255, 255, 0.08) 6px,
+                        transparent 6px, transparent 12px);
+        }
+
+        .control-box.type-dial::before {
+            background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.22), transparent 65%),
+                        conic-gradient(from 0deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0));
+        }
+
+        .control-box.rot {
+            border-color: rgba(255, 70, 70, 0.9);
+            background: linear-gradient(160deg, rgba(80, 10, 20, 0.8), rgba(35, 0, 0, 0.6));
+        }
+        .control-box.grün {
+            border-color: rgba(90, 255, 140, 0.9);
+            background: linear-gradient(160deg, rgba(0, 70, 30, 0.75), rgba(0, 25, 15, 0.6));
+        }
+        .control-box.blau {
+            border-color: rgba(90, 150, 255, 0.9);
+            background: linear-gradient(160deg, rgba(5, 40, 100, 0.8), rgba(0, 20, 60, 0.6));
+        }
+        .control-box.gelb {
+            border-color: rgba(255, 220, 90, 0.9);
+            background: linear-gradient(160deg, rgba(80, 60, 0, 0.75), rgba(45, 30, 0, 0.6));
+        }
+
+        .control-box.active {
+            border-color: rgba(0, 255, 255, 0.95) !important;
+            box-shadow: 0 0 0 3px rgba(0, 180, 255, 0.35), 0 0 45px rgba(0, 255, 255, 0.6);
+            transform: translateY(-6px);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .control-box.active::after {
+            opacity: 0.6;
+        }
+
+        @keyframes targetPulse {
+            0%, 100% { opacity: 0.4; transform: translate(-50%, -50%) scale(1); }
+            50% { opacity: 0.9; transform: translate(-50%, -50%) scale(1.08); }
+        }
+
+        .control-target-indicator {
+            position: absolute;
+            top: 12px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 200, 255, 0.85);
+            color: #001a33;
+            font-weight: bold;
+            padding: 6px 12px;
+            border-radius: 999px;
+            box-shadow: 0 8px 20px rgba(0, 200, 255, 0.45);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            display: none;
+        }
+
+        .control-box.active .control-target-indicator {
+            display: block;
+            animation: targetPulse 1.8s infinite;
+        }
+
+        .control-box.active .control-target-indicator::after {
+            content: attr(data-target);
+            position: absolute;
+            left: 50%;
+            top: 100%;
+            transform: translate(-50%, 8px);
+            background: rgba(0, 40, 80, 0.85);
+            color: #6ff9ff;
+            border-radius: 12px;
+            padding: 4px 10px;
+            font-size: 12px;
+            letter-spacing: 0.5px;
+            white-space: nowrap;
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.35);
+        }
+
         .control-label {
             font-size: 16px;
             font-weight: bold;
-            margin-bottom: 15px;
+            margin-bottom: 18px;
             text-align: center;
+            letter-spacing: 1px;
+            color: #ffffff;
+            text-shadow: 0 0 10px rgba(255, 255, 255, 0.35);
+            white-space: pre-line;
         }
-        
+
         .switch-container {
             display: flex;
             flex-direction: column;
             align-items: center;
             gap: 10px;
         }
-        
+
         .switch-button {
             width: 80px;
             height: 80px;
             border-radius: 50%;
-            border: 4px solid white;
-            background: rgba(255, 255, 255, 0.2);
-            font-size: 32px;
+            border: 4px solid rgba(255, 255, 255, 0.7);
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), rgba(180, 200, 255, 0.2));
+            font-size: 30px;
             font-weight: bold;
             color: white;
             cursor: pointer;
@@ -148,75 +316,194 @@
             align-items: center;
             justify-content: center;
             user-select: none;
+            box-shadow: inset 0 0 15px rgba(0, 0, 0, 0.35), 0 15px 25px rgba(0, 0, 0, 0.35);
         }
-        
+
         .switch-button:active {
             transform: scale(0.9);
-            background: rgba(255, 255, 255, 0.4);
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 1), rgba(120, 160, 255, 0.3));
         }
-        
+
         .slider-container {
             width: 100%;
             display: flex;
             flex-direction: column;
             align-items: center;
+            gap: 10px;
         }
-        
+
         .slider {
             -webkit-appearance: none;
             width: 80%;
             height: 15px;
             border-radius: 10px;
-            background: rgba(255, 255, 255, 0.3);
+            background: linear-gradient(90deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.45));
             outline: none;
             margin: 10px 0;
+            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.35);
         }
-        
+
         .slider::-webkit-slider-thumb {
             -webkit-appearance: none;
             appearance: none;
             width: 40px;
             height: 40px;
             border-radius: 50%;
-            background: white;
+            background: radial-gradient(circle at 30% 30%, #ffffff, #b7e7ff);
             cursor: pointer;
-            border: 3px solid #00ff00;
+            border: 3px solid rgba(0, 255, 255, 0.8);
+            box-shadow: 0 8px 15px rgba(0, 0, 0, 0.4);
         }
-        
+
         .slider::-moz-range-thumb {
             width: 40px;
             height: 40px;
             border-radius: 50%;
-            background: white;
+            background: radial-gradient(circle at 30% 30%, #ffffff, #b7e7ff);
             cursor: pointer;
-            border: 3px solid #00ff00;
+            border: 3px solid rgba(0, 255, 255, 0.8);
+            box-shadow: 0 8px 15px rgba(0, 0, 0, 0.4);
         }
-        
+
         .slider-value {
             font-size: 24px;
             font-weight: bold;
-            color: #00ffff;
+            color: #6ff9ff;
+            text-shadow: 0 0 8px rgba(111, 249, 255, 0.6);
         }
-        
+
+        .button-counter {
+            margin-top: 10px;
+            font-size: 20px;
+            font-weight: bold;
+            color: #ffd15c;
+            text-shadow: 0 0 6px rgba(255, 209, 92, 0.5);
+        }
+
         .button-control {
             width: 100px;
             height: 100px;
             border-radius: 15px;
-            border: 4px solid white;
-            background: linear-gradient(180deg, rgba(255,255,255,0.3) 0%, rgba(255,255,255,0.1) 100%);
+            border: 4px solid rgba(255, 255, 255, 0.8);
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(180, 200, 255, 0.25) 100%);
             font-size: 18px;
             font-weight: bold;
             color: white;
             cursor: pointer;
             transition: all 0.2s;
             user-select: none;
+            box-shadow: 0 15px 30px rgba(0, 0, 0, 0.4);
+            letter-spacing: 1px;
         }
-        
+
         .button-control:active {
             transform: translateY(5px);
-            background: linear-gradient(180deg, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0.3) 100%);
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.55) 100%);
         }
-        
+
+        .toggle-switch {
+            width: 130px;
+            height: 58px;
+            border-radius: 35px;
+            background: linear-gradient(135deg, rgba(80, 80, 80, 0.85), rgba(30, 30, 30, 0.9));
+            border: 3px solid rgba(255, 255, 255, 0.4);
+            position: relative;
+            cursor: pointer;
+            box-shadow: inset 0 0 15px rgba(0, 0, 0, 0.55), 0 12px 25px rgba(0, 0, 0, 0.35);
+            transition: background 0.3s, border-color 0.3s;
+        }
+
+        .toggle-switch.on {
+            background: linear-gradient(135deg, rgba(0, 160, 80, 0.85), rgba(0, 255, 180, 0.8));
+            border-color: rgba(0, 255, 200, 0.8);
+        }
+
+        .toggle-thumb {
+            position: absolute;
+            top: 6px;
+            left: 6px;
+            width: 46px;
+            height: 46px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, #ffffff, #b7e7ff);
+            box-shadow: 0 8px 15px rgba(0, 0, 0, 0.45);
+            transition: transform 0.3s ease;
+        }
+
+        .toggle-switch.on .toggle-thumb {
+            transform: translateX(72px);
+        }
+
+        .toggle-status {
+            margin-top: 12px;
+            font-size: 18px;
+            font-weight: bold;
+            letter-spacing: 1px;
+            color: #6ff9ff;
+            text-shadow: 0 0 8px rgba(111, 249, 255, 0.6);
+        }
+
+        .dial-wrapper {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .dial {
+            width: 130px;
+            height: 130px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35), rgba(30, 50, 90, 0.85));
+            border: 4px solid rgba(255, 255, 255, 0.6);
+            position: relative;
+            box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.6), 0 18px 30px rgba(0, 0, 0, 0.45);
+            touch-action: none;
+            cursor: pointer;
+        }
+
+        .dial::before {
+            content: '';
+            position: absolute;
+            inset: 18px;
+            border-radius: 50%;
+            border: 2px solid rgba(255, 255, 255, 0.25);
+            background: radial-gradient(circle, rgba(0, 0, 0, 0.45) 40%, rgba(0, 0, 0, 0.1));
+        }
+
+        .dial-pointer {
+            position: absolute;
+            top: 14px;
+            left: 50%;
+            width: 6px;
+            height: 45px;
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(90, 150, 255, 0.6));
+            transform-origin: 50% 110px;
+            transform: translateX(-50%) rotate(-135deg);
+            border-radius: 3px;
+            box-shadow: 0 0 12px rgba(111, 249, 255, 0.6);
+        }
+
+        .dial-center {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            transform: translate(-50%, -50%);
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(70, 110, 190, 0.7));
+            border: 2px solid rgba(255, 255, 255, 0.6);
+            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.45);
+        }
+
+        .dial-value {
+            font-size: 20px;
+            font-weight: bold;
+            color: #ffd15c;
+            text-shadow: 0 0 6px rgba(255, 209, 92, 0.6);
+        }
+
         .connection-status {
             position: fixed;
             top: 10px;
@@ -247,6 +534,7 @@
             justify-content: center;
             z-index: 999;
             padding: 20px;
+            backdrop-filter: blur(6px);
         }
         
         .connect-screen input {
@@ -271,10 +559,15 @@
             color: #001a33;
             font-weight: bold;
             cursor: pointer;
+            box-shadow: 0 12px 25px rgba(0, 0, 0, 0.4);
         }
         
         .connect-screen button:active {
             transform: scale(0.95);
+        }
+        @keyframes driftStars {
+            0% { transform: translate3d(0, 0, 0); }
+            100% { transform: translate3d(-200px, -200px, 0); }
         }
     </style>
 </head>
@@ -356,6 +649,7 @@
                     document.getElementById('deviceId').textContent = deviceId;
                     document.getElementById('connectScreen').style.display = 'none';
                     document.getElementById('mainContainer').style.display = 'flex';
+                    document.getElementById('status').classList.remove('success', 'my-turn');
                     renderControls();
                     break;
                     
@@ -363,13 +657,22 @@
                     document.getElementById('problem').textContent = data.problem;
                     document.getElementById('instruction').textContent = data.instruction;
                     document.getElementById('status').classList.remove('success');
+                    clearActiveControl();
+                    const isMyTurn = data.target_device === deviceId;
+                    document.getElementById('status').classList.toggle('my-turn', isMyTurn);
+                    if (isMyTurn) {
+                        highlightControl(data.target_control, data.target_value);
+                    }
                     break;
-                    
+
                 case 'success':
                     document.getElementById('problem').textContent = data.message;
                     document.getElementById('instruction').textContent = `Punkte: ${data.score}`;
-                    document.getElementById('status').classList.add('success');
-                    
+                    const statusElement = document.getElementById('status');
+                    statusElement.classList.add('success');
+                    statusElement.classList.remove('my-turn');
+                    clearActiveControl();
+
                     // Vibriere bei Erfolg (falls unterstützt)
                     if (navigator.vibrate) {
                         navigator.vibrate([100, 50, 100]);
@@ -379,54 +682,74 @@
         }
         
         function renderControls() {
+            clearActiveControl();
             const grid = document.getElementById('controlsGrid');
             grid.innerHTML = '';
             
-            controls.forEach((control, index) => {
+            controls.forEach((control) => {
                 const box = document.createElement('div');
-                box.className = `control-box ${control.color}`;
-                
+                box.classList.add('control-box', control.color, `type-${control.type}`);
+                box.dataset.controlId = control.id;
+
                 const label = document.createElement('div');
                 label.className = 'control-label';
-                label.textContent = `${control.color.toUpperCase()}\n${control.type.toUpperCase()}`;
+                label.textContent = `${control.label.toUpperCase()}\n(${control.color.toUpperCase()})`;
                 box.appendChild(label);
-                
+
+                const targetBadge = document.createElement('div');
+                targetBadge.className = 'control-target-indicator';
+                targetBadge.textContent = 'Einsatz';
+                box.appendChild(targetBadge);
+
                 if (control.type === 'schalter') {
                     const container = document.createElement('div');
                     container.className = 'switch-container';
-                    
+
                     const button = document.createElement('div');
                     button.className = 'switch-button';
-                    button.textContent = control.position || '0';
+                    const min = control.min_value ?? 0;
+                    const max = control.max_value ?? 3;
+                    if (typeof control.position !== 'number') {
+                        control.position = min;
+                    }
+                    button.textContent = control.position;
                     button.onclick = () => {
-                        control.position = (control.position % 3) + 1;
+                        let next = control.position + 1;
+                        if (next > max) {
+                            next = min;
+                        }
+                        control.position = next;
                         button.textContent = control.position;
                         sendControlChange(control.id, control.position);
                     };
-                    
+
                     container.appendChild(button);
                     box.appendChild(container);
                 } else if (control.type === 'slider') {
                     const container = document.createElement('div');
                     container.className = 'slider-container';
-                    
+
                     const slider = document.createElement('input');
                     slider.type = 'range';
-                    slider.min = '0';
-                    slider.max = '3';
-                    slider.value = control.position || '0';
+                    const sliderMin = control.min_value ?? 0;
+                    const sliderMax = control.max_value ?? 3;
+                    slider.min = sliderMin;
+                    slider.max = sliderMax;
+                    const sliderValue = (typeof control.position === 'number') ? control.position : sliderMin;
+                    control.position = sliderValue;
+                    slider.value = sliderValue;
                     slider.className = 'slider';
-                    
+
                     const value = document.createElement('div');
                     value.className = 'slider-value';
                     value.textContent = slider.value;
-                    
+
                     slider.oninput = () => {
-                        control.position = parseInt(slider.value);
+                        control.position = parseInt(slider.value, 10);
                         value.textContent = slider.value;
                         sendControlChange(control.id, control.position);
                     };
-                    
+
                     container.appendChild(slider);
                     container.appendChild(value);
                     box.appendChild(container);
@@ -435,23 +758,226 @@
                     button.className = 'button-control';
                     button.textContent = 'DRÜCK\nMICH!';
                     button.style.whiteSpace = 'pre';
+                    const min = control.min_value ?? 0;
+                    const max = control.max_value ?? 3;
+                    if (typeof control.position !== 'number') {
+                        control.position = min;
+                    }
+
+                    const counter = document.createElement('div');
+                    counter.className = 'button-counter';
+                    counter.textContent = control.position;
                     button.onclick = () => {
-                        control.position = (control.position || 0) + 1;
+                        let next = control.position + 1;
+                        if (next > max) {
+                            next = min;
+                        }
+                        control.position = next;
+                        counter.textContent = control.position;
                         sendControlChange(control.id, control.position);
-                        
+
                         // Visuelles Feedback
-                        button.style.background = 'rgba(255, 255, 255, 0.5)';
+                        button.style.background = 'linear-gradient(180deg, rgba(255, 255, 255, 0.35) 0%, rgba(180, 200, 255, 0.2) 100%)';
                         setTimeout(() => {
-                            button.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.3) 0%, rgba(255,255,255,0.1) 100%)';
+                            button.style.background = 'linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(180, 200, 255, 0.25) 100%)';
                         }, 200);
                     };
                     box.appendChild(button);
+                    box.appendChild(counter);
+                } else if (control.type === 'toggle') {
+                    const container = document.createElement('div');
+                    container.className = 'switch-container';
+
+                    const toggle = document.createElement('div');
+                    toggle.className = 'toggle-switch';
+
+                    const thumb = document.createElement('div');
+                    thumb.className = 'toggle-thumb';
+                    toggle.appendChild(thumb);
+
+                    const min = control.min_value ?? 0;
+                    const max = control.max_value ?? 1;
+                    if (typeof control.position !== 'number') {
+                        control.position = min;
+                    }
+
+                    const status = document.createElement('div');
+                    status.className = 'toggle-status';
+
+                    const updateToggle = () => {
+                        const isOn = control.position === max;
+                        toggle.classList.toggle('on', isOn);
+                        status.textContent = isOn ? 'AN' : 'AUS';
+                    };
+
+                    toggle.onclick = () => {
+                        control.position = (control.position === max) ? min : max;
+                        updateToggle();
+                        sendControlChange(control.id, control.position);
+                    };
+
+                    updateToggle();
+
+                    container.appendChild(toggle);
+                    container.appendChild(status);
+                    box.appendChild(container);
+                } else if (control.type === 'dial') {
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'dial-wrapper';
+
+                    const dial = document.createElement('div');
+                    dial.className = 'dial';
+
+                    const pointer = document.createElement('div');
+                    pointer.className = 'dial-pointer';
+                    dial.appendChild(pointer);
+
+                    const center = document.createElement('div');
+                    center.className = 'dial-center';
+                    dial.appendChild(center);
+
+                    const min = control.min_value ?? 0;
+                    const max = control.max_value ?? 5;
+                    if (typeof control.position !== 'number') {
+                        control.position = min;
+                    }
+
+                    const valueDisplay = document.createElement('div');
+                    valueDisplay.className = 'dial-value';
+
+                    const clamp = (val) => Math.min(max, Math.max(min, val));
+
+                    const updateDial = () => {
+                        const range = max - min;
+                        const ratio = range === 0 ? 0 : (control.position - min) / range;
+                        const angle = -135 + (ratio * 270);
+                        pointer.style.transform = `translateX(-50%) rotate(${angle}deg)`;
+                        valueDisplay.textContent = control.position;
+                    };
+
+                    let dragging = false;
+
+                    const setFromEvent = (event) => {
+                        const rect = dial.getBoundingClientRect();
+                        const cx = rect.left + rect.width / 2;
+                        const cy = rect.top + rect.height / 2;
+                        const dx = event.clientX - cx;
+                        const dy = cy - event.clientY;
+                        const angle = Math.atan2(dy, dx) * (180 / Math.PI);
+                        const clampedAngle = Math.min(135, Math.max(-135, angle));
+                        const ratio = (clampedAngle + 135) / 270;
+                        const nextValue = clamp(Math.round(min + ratio * (max - min)));
+                        if (nextValue !== control.position) {
+                            control.position = nextValue;
+                            updateDial();
+                            sendControlChange(control.id, control.position);
+                        }
+                    };
+
+                    dial.addEventListener('pointerdown', (event) => {
+                        event.preventDefault();
+                        dragging = true;
+                        dial.setPointerCapture(event.pointerId);
+                        setFromEvent(event);
+                    });
+
+                    dial.addEventListener('pointermove', (event) => {
+                        if (!dragging) return;
+                        setFromEvent(event);
+                    });
+
+                    const stopDragging = (event) => {
+                        if (!dragging) return;
+                        dragging = false;
+                        try {
+                            dial.releasePointerCapture(event.pointerId);
+                        } catch (error) {
+                            // ignore if pointer capture already released
+                        }
+                    };
+
+                    dial.addEventListener('pointerup', stopDragging);
+                    dial.addEventListener('pointercancel', stopDragging);
+                    dial.addEventListener('lostpointercapture', () => {
+                        dragging = false;
+                    });
+
+                    dial.addEventListener('wheel', (event) => {
+                        event.preventDefault();
+                        const direction = event.deltaY > 0 ? -1 : 1;
+                        const nextValue = clamp(control.position + direction);
+                        if (nextValue !== control.position) {
+                            control.position = nextValue;
+                            updateDial();
+                            sendControlChange(control.id, control.position);
+                        }
+                    });
+
+                    updateDial();
+
+                    wrapper.appendChild(dial);
+                    wrapper.appendChild(valueDisplay);
+                    box.appendChild(wrapper);
                 }
-                
+
                 grid.appendChild(box);
             });
         }
-        
+
+        function findControl(controlId) {
+            return controls.find((ctrl) => ctrl.id === controlId);
+        }
+
+        function formatTargetHint(control, targetValue) {
+            if (!control) {
+                return '';
+            }
+
+            const label = control.label || 'Ziel';
+
+            switch (control.type) {
+                case 'toggle': {
+                    const isOn = targetValue === (control.max_value ?? 1);
+                    return `${label}: ${isOn ? 'AN' : 'AUS'}`;
+                }
+                case 'slider':
+                case 'dial':
+                    return `${label}: Stufe ${targetValue}`;
+                case 'schalter':
+                    return `${label}: Position ${targetValue}`;
+                default:
+                    return `${label}: ${targetValue}`;
+            }
+        }
+
+        function highlightControl(controlId, targetValue) {
+            const safeId = window.CSS && window.CSS.escape
+                ? window.CSS.escape(controlId)
+                : controlId.replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+            const selector = `.control-box[data-control-id="${safeId}"]`;
+            const box = document.querySelector(selector);
+            if (!box) {
+                return;
+            }
+
+            box.classList.add('active');
+            const badge = box.querySelector('.control-target-indicator');
+            if (badge) {
+                const control = findControl(controlId);
+                badge.dataset.target = formatTargetHint(control, targetValue);
+            }
+        }
+
+        function clearActiveControl() {
+            document.querySelectorAll('.control-box.active').forEach((box) => {
+                box.classList.remove('active');
+                const badge = box.querySelector('.control-target-indicator');
+                if (badge) {
+                    delete badge.dataset.target;
+                }
+            });
+        }
+
         function sendControlChange(controlId, value) {
             if (ws && ws.readyState === WebSocket.OPEN) {
                 ws.send(JSON.stringify({

--- a/space_server.py
+++ b/space_server.py
@@ -6,12 +6,47 @@ import tkinter as tk
 from threading import Thread
 
 class SpaceGameServer:
+    CONTROL_LIBRARY = [
+        {"name": "Antrieb", "type": "schalter", "color": "rot", "min_value": 0, "max_value": 3},
+        {"name": "Schilde", "type": "slider", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Navigation", "type": "knopf", "color": "grün", "min_value": 0, "max_value": 3},
+        {"name": "Kommunikation", "type": "schalter", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Triebwerk", "type": "slider", "color": "rot", "min_value": 0, "max_value": 4},
+        {"name": "Scanner", "type": "knopf", "color": "blau", "min_value": 0, "max_value": 4},
+        {"name": "Laser", "type": "knopf", "color": "rot", "min_value": 0, "max_value": 3},
+        {"name": "Fracht", "type": "slider", "color": "grün", "min_value": 0, "max_value": 5},
+        {"name": "Sauerstoff", "type": "schalter", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Gravitation", "type": "slider", "color": "gelb", "min_value": 0, "max_value": 3},
+        {"name": "Lebenserhaltung", "type": "schalter", "color": "grün", "min_value": 0, "max_value": 2},
+        {"name": "Turbinen", "type": "slider", "color": "rot", "min_value": 0, "max_value": 4},
+        {"name": "Dock", "type": "knopf", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Sensor Boost", "type": "slider", "color": "blau", "min_value": 0, "max_value": 5},
+        {"name": "Plasma", "type": "schalter", "color": "rot", "min_value": 0, "max_value": 3},
+        {"name": "Schildgenerator", "type": "knopf", "color": "grün", "min_value": 0, "max_value": 4},
+        {"name": "Funk", "type": "slider", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Verteidigung", "type": "schalter", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Warp", "type": "slider", "color": "grün", "min_value": 0, "max_value": 4},
+        {"name": "Kühlung", "type": "schalter", "color": "gelb", "min_value": 0, "max_value": 2},
+        {"name": "Analyse", "type": "knopf", "color": "blau", "min_value": 0, "max_value": 3},
+        {"name": "Versorgung", "type": "slider", "color": "grün", "min_value": 0, "max_value": 5},
+        {"name": "Stabilisator", "type": "schalter", "color": "rot", "min_value": 0, "max_value": 2},
+        {"name": "Hangar", "type": "knopf", "color": "gelb", "min_value": 0, "max_value": 3},
+        {"name": "Reaktor Sicherung", "type": "toggle", "color": "rot", "min_value": 0, "max_value": 1},
+        {"name": "Orbit Dial", "type": "dial", "color": "blau", "min_value": 0, "max_value": 8},
+        {"name": "Andock Taster", "type": "toggle", "color": "gelb", "min_value": 0, "max_value": 1},
+        {"name": "Grav-Justierer", "type": "dial", "color": "grün", "min_value": 0, "max_value": 10},
+    ]
+
     def __init__(self):
         self.clients = {}
+        self.client_controls = {}
+        self.client_control_specs = {}
         self.current_task = None
         self.score = 0
         self.game_active = False
         self.loop = None
+        self.available_controls = self.CONTROL_LIBRARY.copy()
+        self.extra_control_counter = 1
         self.problems = [
             "WARNUNG: Sauerstoff niedrig!",
             "ALARM: Energiekern überhitzt!",
@@ -19,55 +54,100 @@ class SpaceGameServer:
             "GEFAHR: Antrieb ausgefallen!",
             "WARNUNG: Sensoren offline!"
         ]
-        
+
     async def register_client(self, websocket):
         client_id = f"device_{len(self.clients) + 1}"
         self.clients[client_id] = websocket
         print(f"Neues Gerät verbunden: {client_id}")
-        
+
+        controls = self.generate_controls(client_id)
+        self.client_controls[client_id] = controls
+
         # Sende Geräte-ID und initiale Konfiguration
         await websocket.send(json.dumps({
             "type": "init",
             "device_id": client_id,
-            "controls": self.generate_controls()
+            "controls": controls
         }))
-        
+
+        self.update_gui()
+
         try:
             async for message in websocket:
                 data = json.loads(message)
                 await self.handle_message(data, client_id)
         except websockets.exceptions.ConnectionClosed:
             print(f"Gerät getrennt: {client_id}")
+        finally:
             if client_id in self.clients:
                 del self.clients[client_id]
+
+            if client_id in self.client_controls:
+                del self.client_controls[client_id]
+
+            if client_id in self.client_control_specs:
+                self.available_controls.extend(self.client_control_specs[client_id])
+                del self.client_control_specs[client_id]
+
+            if self.current_task and self.current_task.get("device_id") == client_id:
+                self.current_task = None
+
             self.update_gui()
-    
-    def generate_controls(self):
-        colors = ["rot", "grün", "blau", "gelb"]
-        shapes = ["rund", "eckig"]
-        control_types = ["schalter", "slider", "knopf"]
-        
+
+    def generate_controls(self, client_id):
+        if len(self.available_controls) < 6:
+            assigned_specs = []
+            for specs in self.client_control_specs.values():
+                assigned_specs.extend(specs)
+
+            self.available_controls = [
+                spec for spec in self.CONTROL_LIBRARY
+                if spec not in assigned_specs
+            ]
+
+            if len(self.available_controls) < 6:
+                # Falls nicht genug einzigartige Kontrollen verfügbar sind,
+                # generieren wir zusätzliche Varianten mit nummerierten Namen.
+                extra_controls = []
+                while len(self.available_controls) + len(extra_controls) < 6:
+                    template = random.choice(self.CONTROL_LIBRARY)
+                    extra = template.copy()
+                    extra["name"] = f"{template['name']} {self.extra_control_counter}"
+                    extra_controls.append(extra)
+                    self.extra_control_counter += 1
+
+                self.available_controls.extend(extra_controls)
+
+        selected_specs = random.sample(self.available_controls, k=6)
+        for spec in selected_specs:
+            self.available_controls.remove(spec)
+
+        self.client_control_specs[client_id] = selected_specs
+
         controls = []
-        for i in range(6):
-            control = {
-                "id": f"control_{i}",
-                "type": random.choice(control_types),
-                "color": random.choice(colors),
-                "shape": random.choice(shapes) if random.random() > 0.5 else None,
-                "position": 0
-            }
-            controls.append(control)
+        for index, spec in enumerate(selected_specs):
+            controls.append({
+                "id": f"{client_id}_control_{index}",
+                "type": spec["type"],
+                "color": spec["color"],
+                "label": spec["name"],
+                "min_value": spec.get("min_value", 0),
+                "max_value": spec.get("max_value", 3),
+                "position": spec.get("min_value", 0)
+            })
+
         return controls
-    
+
     async def handle_message(self, data, client_id):
         if data["type"] == "control_change":
             await self.check_solution(data, client_id)
-    
+
     async def check_solution(self, data, client_id):
         if not self.current_task:
             return
-        
-        if (data["control_id"] == self.current_task["target_control"] and
+
+        if (client_id == self.current_task.get("device_id") and
+            data["control_id"] == self.current_task["target_control"] and
             data["value"] == self.current_task["target_value"]):
             self.score += 10
             await self.broadcast({
@@ -75,47 +155,93 @@ class SpaceGameServer:
                 "message": "SUPER! Problem gelöst! ⭐",
                 "score": self.score
             })
+            self.current_task = None
             self.update_gui()
             await asyncio.sleep(2)
             await self.send_new_task()
-    
+
     async def send_new_task(self):
         if not self.clients or not self.game_active:
             return
-        
-        # Wähle zufälliges Gerät und Kontrolle
-        device_id = random.choice(list(self.clients.keys()))
-        control_id = f"control_{random.randint(0, 5)}"
-        target_value = random.randint(1, 3)
-        
-        # Hole Kontrollinformationen (simuliert)
-        colors = ["rot", "grün", "blau", "gelb"]
-        types = ["Schalter", "Slider", "Knopf"]
-        
-        instruction = f"{random.choice(colors).capitalize()} {random.choice(types)} auf Position {target_value}!"
-        
+
+        device_id = random.choice(list(self.client_controls.keys()))
+        available_controls = self.client_controls.get(device_id, [])
+
+        if not available_controls:
+            return
+
+        control = random.choice(available_controls)
+        target_value = self.generate_target_value(control)
+        instruction = self.build_instruction(device_id, control, target_value)
+
         self.current_task = {
-            "target_control": control_id,
+            "device_id": device_id,
+            "target_control": control["id"],
             "target_value": target_value,
             "problem": random.choice(self.problems),
             "instruction": instruction
         }
-        
+
         await self.broadcast({
             "type": "new_task",
             "problem": self.current_task["problem"],
-            "instruction": instruction
+            "instruction": instruction,
+            "target_device": device_id,
+            "target_control": control["id"],
+            "target_value": target_value
         })
-        
+
         self.update_gui()
-    
+
+    def generate_target_value(self, control):
+        min_value = control.get("min_value", 0)
+        max_value = control.get("max_value", 3)
+
+        if control["type"] in {"slider", "dial"}:
+            return random.randint(min_value, max_value)
+
+        if control["type"] == "schalter":
+            return random.randint(min_value, max_value)
+
+        if control["type"] == "toggle":
+            return random.choice([min_value, max_value])
+
+        # knopf
+        target = random.randint(min_value + 1, max_value)
+        return target
+
+    def build_instruction(self, device_id, control, target_value):
+        type_labels = {
+            "schalter": "Schalter",
+            "slider": "Regler",
+            "knopf": "Knopf",
+            "toggle": "Schalter",
+            "dial": "Drehregler",
+        }
+
+        color = control.get("color", "").capitalize()
+        label = control.get("label", "Kontrolle")
+        type_label = type_labels.get(control.get("type"), "Kontrolle")
+
+        if control["type"] in {"slider", "dial"}:
+            return (f"{device_id.upper()}: Stelle den {color} {type_label} '{label}' auf Stufe {target_value}.")
+
+        if control["type"] == "toggle":
+            state = "AN" if target_value == control.get("max_value", 1) else "AUS"
+            return (f"{device_id.upper()}: Schalte '{label}' ({color}) auf {state}.")
+
+        if control["type"] == "schalter":
+            return (f"{device_id.upper()}: Schalte '{label}' ({color}) auf Position {target_value}.")
+
+        return (f"{device_id.upper()}: Drücke '{label}' ({color}) bis Anzeige {target_value} leuchtet.")
+
     async def broadcast(self, message):
         if self.clients:
             await asyncio.gather(
                 *[client.send(json.dumps(message)) for client in self.clients.values()],
                 return_exceptions=True
             )
-    
+
     def update_gui(self):
         if hasattr(self, 'gui') and self.gui:
             try:
@@ -126,8 +252,9 @@ class SpaceGameServer:
     async def start_game(self):
         self.game_active = True
         self.score = 0
+        self.current_task = None
         await self.send_new_task()
-    
+
     async def stop_game(self):
         self.game_active = False
         self.current_task = None


### PR DESCRIPTION
## Summary
- add type-specific panel overlays and animated target badges so the active control is clearly highlighted on the client
- broadcast the target control id and value with each task so devices can display precise action hints

## Testing
- python -m compileall space_server.py space_client.html

------
https://chatgpt.com/codex/tasks/task_e_68e4e45d76a4832c9857fc78fabc7dee